### PR TITLE
[AWS DevOps] Task 5:  "Simple" Application Deployment with Helm

### DIFF
--- a/bastion_host.sh
+++ b/bastion_host.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# NAT Instance configuration
+sudo yum install iptables-services -y
+sudo systemctl enable iptables
+sudo systemctl start iptables
+sudo sysctl -w net.ipv4.ip_forward=1
+sudo /sbin/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+sudo /sbin/iptables -F FORWARD
+
+# Setup Reverse Proxy
+# Install nginx on AL2:
+sudo amazon-linux-extras install nginx1 -y
+sudo systemctl start nginx.service
+# Configure reverse-proxy. The Private IP of k3s Server instance must be declared
+sudo touch /etc/nginx/conf.d/proxy.conf
+sudo echo 'server {
+        listen 80;
+        server_name localhost 127.0.0.1;
+        location / {
+          proxy_pass         http://10.0.3.191:32000;
+          proxy_redirect     off;
+          proxy_set_header   Host $host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Host $server_name;
+        }
+    }' >> /etc/nginx/conf.d/proxy.conf
+sudo service nginx restart
+# Accept inbound connections on port 80
+sudo iptables -I INPUT -p tcp --dport 80 -j ACCEPT

--- a/ec2.tf
+++ b/ec2.tf
@@ -13,16 +13,7 @@ resource "aws_instance" "nat_instance" {
     device_index         = 0
     network_card_index   = 0
   }
-  user_data                   = <<-EOL
-                #! /bin/bash
-                sudo yum install iptables-services -y
-                sudo systemctl enable iptables
-                sudo systemctl start iptables
-                sudo sysctl -w net.ipv4.ip_forward=1
-                sudo /sbin/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-                sudo /sbin/iptables -F FORWARD
-              EOL
-  user_data_replace_on_change = true
+  user_data = templatefile("bastion_host.sh", {})
 }
 
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "nat_instance" {
 # Create a k3s Server instance in Private subnet #1
 resource "aws_instance" "k3s_server" {
   ami                    = var.ec2_amazon_linux_ami
-  instance_type          = "t2.micro" # we won't need t2.small for this task.
+  instance_type          = "t2.small"
   subnet_id              = aws_subnet.private_subnet_1.id
   vpc_security_group_ids = [aws_security_group.k3s_server_sg.id]
   key_name               = aws_key_pair.ssh_key.key_name

--- a/ec2.tf
+++ b/ec2.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "nat_instance" {
 # Create a k3s Server instance in Private subnet #1
 resource "aws_instance" "k3s_server" {
   ami                    = var.ec2_amazon_linux_ami
-  instance_type          = "t2.small"
+  instance_type          = "t2.micro" # we won't need t2.small for this task.
   subnet_id              = aws_subnet.private_subnet_1.id
   vpc_security_group_ids = [aws_security_group.k3s_server_sg.id]
   key_name               = aws_key_pair.ssh_key.key_name

--- a/k3s_server.sh
+++ b/k3s_server.sh
@@ -9,7 +9,7 @@ curl -sfL https://get.k3s.io | K3S_TOKEN=${token} sh -s -
 
 # Configure kubeconfig for non-root access
 sudo ln -s /usr/local/bin/k3s /usr/bin/k3s
-mkdir -p ~/.kube
+mkdir ~/.kube
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 sudo chown ec2-user:ec2-user ~/.kube/config
 sudo chmod 600 ~/.kube/config

--- a/network_acls.tf
+++ b/network_acls.tf
@@ -8,30 +8,7 @@ resource "aws_network_acl" "public_acl" {
   }
 }
 
-# Add ingress rules to Public ACL to allow ssh & icmp inbound traffic
-resource "aws_network_acl_rule" "ingress_icmp" {
-  network_acl_id = aws_network_acl.public_acl.id
-  rule_number    = 100
-  egress         = false
-  protocol       = "icmp"
-  rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
-  icmp_type      = -1
-  icmp_code      = -1
-}
-
-resource "aws_network_acl_rule" "ingress_ssh" {
-  network_acl_id = aws_network_acl.public_acl.id
-  rule_number    = 101
-  egress         = false
-  protocol       = "tcp"
-  rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
-  from_port      = 22
-  to_port        = 22
-}
-
-# Allow all inbound traffic, RM if not needed
+# Allow all inbound traffic for now
 resource "aws_network_acl_rule" "ingress_allow_all" {
   network_acl_id = aws_network_acl.public_acl.id
   rule_number    = 200 # Choose a rule number that is higher than existing rules

--- a/sg.tf
+++ b/sg.tf
@@ -85,7 +85,17 @@ resource "aws_security_group" "k3s_server_sg" {
   }
 }
 
-# Add Ingress Rules to allow ssh inbound traffic to k3s Server
+# Add Ingress Rules to allow specific inbound traffic to k3s Server
+resource "aws_security_group_rule" "ingress_ephemeral_k3s_server" {
+  description       = "Allow inbound traffic to ephemeral ports on k3s Server instance within VPC"
+  security_group_id = aws_security_group.k3s_server_sg.id
+  type              = "ingress"
+  cidr_blocks       = [var.vpc_cidr]
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "tcp"
+}
+
 resource "aws_security_group_rule" "ingress_ssh_k3s_server" {
   description       = "Allow inbound SSH traffic to k3s Server instance within VPC"
   security_group_id = aws_security_group.k3s_server_sg.id
@@ -157,6 +167,16 @@ resource "aws_security_group_rule" "ingress_ssh_k3s_agent" {
   cidr_blocks       = [var.vpc_cidr]
   from_port         = 22
   to_port           = 22
+  protocol          = "tcp"
+}
+
+resource "aws_security_group_rule" "ingress_ephemeral_k3s_agent" {
+  description       = "Allow inbound traffic to ephemeral ports on k3s Agent instance within VPC"
+  security_group_id = aws_security_group.k3s_agent_sg.id
+  type              = "ingress"
+  cidr_blocks       = [var.vpc_cidr]
+  from_port         = 30000
+  to_port           = 32767
   protocol          = "tcp"
 }
 

--- a/sg.tf
+++ b/sg.tf
@@ -21,6 +21,17 @@ resource "aws_security_group_rule" "ingress_ssh" {
   protocol          = "tcp"
 }
 
+# Add Ingress Rules to allow http inbound traffic for reverse-proxy setup
+resource "aws_security_group_rule" "ingress_http" {
+  description       = "Allow inbound HTTP traffic to NAT Instance / Bastion Host from specified IP Range"
+  security_group_id = aws_security_group.nat_sg.id
+  type              = "ingress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+}
+
 resource "aws_security_group_rule" "ingress_icmp" {
   description       = "Allow inbound ICMP (Ping) traffic to NAT Instance / Bastion Host"
   security_group_id = aws_security_group.nat_sg.id


### PR DESCRIPTION
## "Simple" Application Deployment with Helm
###  Changes to the infrastructure were made in order to complete Task 5:
  - Bastion/NAT Instance now supports Reverse Proxy connection on port 80: [ec2.tf](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_5/ec2.tf), [bastion_host.sh](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_5/bastion_host.sh)
  - Removed useless NACLs [network_acls.tf](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_5/network_acls.tf)
  - Updated NAT Instance Security Group to allow inbound traffic from ephemeral ports 30000-32767 [sg.tf](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_5/sg.tf)
### Current Infrastracture Configuration (remains the same):
![image](https://github.com/user-attachments/assets/e5b8f5f1-2ffd-4b33-a005-39449aa39771)

> [!NOTE]  
> As always, the infrastracture is destroyed to save $$$