### PR TITLE
[AWS DevOps] Task 7: Prometheus Deployment on K8s

### DIFF
--- a/bastion_host.sh
+++ b/bastion_host.sh
@@ -17,8 +17,8 @@ sudo echo 'server {
         listen 80;
         server_name localhost 127.0.0.1;
         location / {
-          proxy_pass         http://10.0.3.129:32000;
-          proxy_redirect     off;
+          proxy_pass         http://10.0.3.58:32000;
+          proxy_redirect     http://10.0.3.58:32000/ /;
           proxy_set_header   Host $host;
           proxy_set_header   X-Real-IP $remote_addr;
           proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/k3s_server.sh
+++ b/k3s_server.sh
@@ -9,12 +9,12 @@ curl -sfL https://get.k3s.io | K3S_TOKEN=${token} sh -s -
 
 # Configure kubeconfig for non-root access
 sudo ln -s /usr/local/bin/k3s /usr/bin/k3s
-sudo mkdir -p ~/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-sudo chown ec2-user:ec2-user ~/.kube/config
-sudo chmod 600 ~/.kube/config
-echo 'export KUBECONFIG=~/.kube/config' >> ~/.bashrc
-source ~/.bashrc
+sudo mkdir -p /home/ec2-user/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml /home/ec2-user/.kube/config
+sudo chown ec2-user:ec2-user /home/ec2-user/.kube/config
+sudo chmod 600 /home/ec2-user/.kube/config
+echo 'export KUBECONFIG=/home/ec2-user/.kube/config' >> /home/ec2-user/.bashrc
+source /home/ec2-user/.bashrc
 
 # Install Telnet
 sudo yum install telnet -y

--- a/sg.tf
+++ b/sg.tf
@@ -139,6 +139,17 @@ resource "aws_security_group_rule" "ingress_metrics_k3s_server" {
   protocol          = "tcp"
 }
 
+# Allow Prometheus Node Exporter Metrics
+resource "aws_security_group_rule" "ingress_node_exporter_k3s_server" {
+  description       = "Allow inbound traffic to k3s Agent for Node Exporter metrics"
+  security_group_id = aws_security_group.k3s_server_sg.id
+  type              = "ingress"
+  cidr_blocks       = [var.vpc_cidr]
+  from_port         = 9100
+  to_port           = 9100
+  protocol          = "tcp"
+}
+
 resource "aws_security_group_rule" "egress_any_k3s_server" {
   description       = "Allow any outbound traffic from k3s Server Instance"
   security_group_id = aws_security_group.k3s_server_sg.id
@@ -199,6 +210,17 @@ resource "aws_security_group_rule" "ingress_metrics_k3s_agent" {
   cidr_blocks       = [var.vpc_cidr]
   from_port         = 10250
   to_port           = 10250
+  protocol          = "tcp"
+}
+
+# Allow Prometheus Node Exporter Metrics
+resource "aws_security_group_rule" "ingress_node_exporter_k3s_agent" {
+  description       = "Allow inbound traffic to k3s Agent for Node Exporter metrics"
+  security_group_id = aws_security_group.k3s_agent_sg.id
+  type              = "ingress"
+  cidr_blocks       = [var.vpc_cidr]
+  from_port         = 9100
+  to_port           = 9100
   protocol          = "tcp"
 }
 


### PR DESCRIPTION
## AWS Kubernetes Cluster Updates, Issued for Task 7:
 * Added New Security Group Rules For k3s nodes to allow Prometheus' Node Exporters traffic on port 9100 [sg.tf](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_7/sg.tf)
 * Miner fixes in user data scripts [bastion_host.sh](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_7/bastion_host.sh), [k3s_server.sh](https://github.com/december-man/rsschool-devops-course-infrastrutture/blob/task_7/k3s_server.sh)
### The infrastructure remains the same as of Task 5:
![image](https://github.com/user-attachments/assets/eafb68c7-9e52-4522-ae7b-f210b0e76a99)